### PR TITLE
Use error handler and fix response header names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @openapi-generator-plus/typescript-express-passport-server-generator
 
+## 2.7.0
+
+### Minor Changes
+
+- 249dd97: keep header name same as in OpenAPI spec file
+- fe7348c: pass HttpStatusError to next (NextFunction)
+- efd94c7: throw HttpStatusError 501 for stubbed functions
+- 242910e: change npm & github orgs, increment minor version
+
 ## 2.6.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@openapi-generator-plus/typescript-express-passport-server-generator",
-  "version": "2.6.0",
+  "name": "@stevegoossens/typescript-express-passport-server-generator",
+  "version": "2.7.0",
   "description": "An OpenAPI Generator+ module for an Express + Passport API server in TypeScript",
   "keywords": [
     "openapi-generator-plus",
@@ -22,7 +22,7 @@
     "test": "jest",
     "watch": "tsc --watch"
   },
-  "author": "Karl von Randow",
+  "author": "Karl von Randow, Steve Goossens",
   "license": "Apache-2.0",
   "dependencies": {
     "@openapi-generator-plus/core": "^2.1.0",
@@ -55,6 +55,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/karlvr/openapi-generator-plus-express-passport.git"
+    "url": "git+https://github.com/stevegoossens/openapi-generator-plus-express-passport.git"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ const createGenerator: CodegenGeneratorConstructor = (config, context) => {
 		await emit('validation', path.join(outputPath, relativeSourceOutputPath, 'validation.ts'), { ...rootContext, ...doc }, true, hbs)
 		await emit('index', path.join(outputPath, relativeSourceOutputPath, 'index.ts'), { ...rootContext, ...doc }, true, hbs)
 		await emit('indexTypes', path.join(outputPath, relativeSourceOutputPath, 'types.ts'), { ...rootContext, ...doc }, true, hbs)
+		await emit('errors', path.join(outputPath, relativeSourceOutputPath, 'errors.ts'), { ...rootContext, ...doc }, true, hbs)
 	}
 
 	const base = typescriptGenerator(config, myContext)

--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -72,7 +72,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 						res.status({{code}})
 						{{#if headers}}
 						{{#each headers}}
-						res.header({{{stringLiteral name}}}, `${response.headers[{{{stringLiteral name}}}]}`)
+						res.header({{{stringLiteral serializedName}}}, `${response.headers[{{{stringLiteral name}}}]}`)
 						{{/each}}
 						{{/if}}
 						{{#if defaultContent.schema}}

--- a/templates/api.hbs
+++ b/templates/api.hbs
@@ -5,20 +5,19 @@ import passport from 'passport'
 import * as t from './types'
 import * as v from '../../validation'
 import { Api } from '../../models'
+import { HttpStatusError } from '../../errors'
 
 export default function(app: Express, impl: t.{{className name}}Api) {
 	{{#each operations}}
 	app.{{lowerCase httpMethod}}(
 		{{{stringLiteral (pathTemplate fullPath)}}},
 		{{>frag/apiSecurityRequirements}}
-		function (req, res) {
+		function (req, res, next) {
 			try {
 				{{#if securityRequirements}}
 				const __user = req.user
 				if (!__user) {
-					res.status(401)
-					res.send()
-					return
+					return next(HttpStatusError.unauthorized())
 				}
 				{{/if}}
 				{{#if requestBody.defaultContent.schema}}
@@ -46,7 +45,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 					{{/each}}
 					{{/with}}
 					console.error(`Invalid request content type: ${__contentType}`)
-					throw new Error(`Invalid request content type: ${__contentType}`)
+					throw new HttpStatusError(`Invalid request content type: ${__contentType}`, 415)
 				}
 
 				{{/if}}
@@ -63,9 +62,7 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 							body = {{>frag/toJson defaultContent.schema prefix='v.'}}('response', response.body)
 						} catch (error) {
 							console.error('Invalid response body in {{identifier ../../name}}.{{identifier ../name}}', error)
-							res.status(500)
-							res.send()
-							return
+							return next(HttpStatusError.for(error))
 						}
 
 						{{/if}}
@@ -85,17 +82,16 @@ export default function(app: Express, impl: t.{{className name}}Api) {
 					{{/each}}
 
 					console.log('Unsupported response in {{identifier ../name}}.{{identifier name}}', response)
-					res.status(500)
-					res.send()
+					return next(new HttpStatusError('Unsupported response status code', 500))
 				}).catch(function (error) {
 					console.error('Unexpected error in {{identifier ../name}}.{{identifier name}}', error.stack || error)
-					res.status(500)
-					res.send()
+					return next(HttpStatusError.for(error))
 				})
 			} catch (error) {
 				/* Catch validation errors */
-				res.status(400)
-				res.send(error)
+				const httpStatusError = HttpStatusError.for(error)
+				httpStatusError.statusCode ??= 400
+				return next(httpStatusError)
 			}
 		}
 	)

--- a/templates/apiImpl.hbs
+++ b/templates/apiImpl.hbs
@@ -1,4 +1,5 @@
 import * as t from '../api/{{identifier name}}/types'
 import { Api } from '../models'
+import { HttpStatusError } from '../errors'
 
 {{>frag/apiImpl}}

--- a/templates/errors.hbs
+++ b/templates/errors.hbs
@@ -1,0 +1,63 @@
+{{>header}}
+
+/**
+ * HTTP Status error class
+ */
+export class HttpStatusError extends Error {
+  headers?: Record<string, string>;
+  statusCode?: number;
+
+  /**
+   * 
+   * @param message Error message
+   * @param statusCode HTTP Status code
+   * @param headers HTTP response headers
+   */
+  constructor(message: string, statusCode?: number, headers?: Record<string, string>) {
+    super(message);
+    this.name = 'HttpStatusError';
+    this.statusCode = statusCode;
+    this.headers = headers;
+  }
+
+  /**
+   * Provides a HttpStatusError for
+   * - a HttpStatusError
+   * - a regular Error
+   * - a string-only throw
+   * 
+   * This allows a unified/consistent HttpStatusError to be passed to a
+   * single error handler in Express
+   * 
+   * @param error 
+   * @param statusCode 
+   * @returns 
+   */
+  public static for(
+    error: HttpStatusError | Error | string | unknown,
+    statusCode?: number
+  ): HttpStatusError {
+    if (error instanceof HttpStatusError) {
+      return error
+    } else if (error instanceof Error) {
+      return new HttpStatusError(error.message, statusCode)
+    } else if (typeof(error) === 'string') {
+      return new HttpStatusError(error, statusCode)
+    } else {
+      return new HttpStatusError('Internal Server Error', 500)
+    }
+  }
+
+  public static unauthorized(): HttpStatusError {
+    return new HttpStatusError(
+      'Unauthorized',
+      401,
+      {
+        'Access-Control-Allow-Headers':
+          'Content-Type, Authorization, Accept, X-Requested-With',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, LOGIN, DELETE',
+        'Access-Control-Allow-Origin': '*'
+      }
+    )
+  }
+}

--- a/templates/frag/apiImpl.hbs
+++ b/templates/frag/apiImpl.hbs
@@ -3,7 +3,7 @@ async function {{identifier name}}({{#each parameters}}{{identifier name}}: {{{n
 	--}}{{#if requestBody.nativeType}}{{#if parameters}}, {{/if}}{{identifier requestBody.name}}: {{{requestBody.nativeType}}}{{#unless requestBody.required}} | undefined{{/unless}}{{/if}}{{!--
 	--}}{{#if securityRequirements}}{{#or requestBody parameters}}, {{/or}}__user: any{{/if}}{{!--
 	--}}): Promise<t.{{className name}}Response> {
-	throw 'Unimplemented'
+	throw new HttpStatusError('Unimplemented', 501)
 }
 
 {{/each}}


### PR DESCRIPTION
- fixes header names to be the same as in the OpenAPI spec (instead of changing to camelCase!)
- replaces the empty body responses with passing a custom error (HttpStatusError) to the `next` (`NextFunction`) of `Express`
  - this allows a single error handler middleware function to be added to format the response body, and also send headers, for all errors